### PR TITLE
Add defintion of the ssize_t type on windows systems

### DIFF
--- a/src/ckdtree/ckdtree_decl.h
+++ b/src/ckdtree/ckdtree_decl.h
@@ -31,6 +31,12 @@
     #endif
 #endif
 
+// define the ssize_t type for windows systems
+#if defined(_MSC_VER)
+#include <BaseTsd.h>
+typedef SSIZE_T ssize_t;
+#endif
+
 
 #define ckdtree_intp_t ssize_t
 


### PR DESCRIPTION
ssize_t is not defined by default on windows systems, so we have to define it explicitly. This fixes #7.