### PR TITLE
suppress unavoidable numba warnings related to parallel and reflected lists

### DIFF
--- a/examples/example_knn.py
+++ b/examples/example_knn.py
@@ -6,7 +6,7 @@ data = np.random.random(3_000_000).reshape(-1, 3).astype(np.float32)
 kdtree = KDTree(data, leafsize=10)
 
 # query the nearest neighbors of the first 100 points
-distances, indices = kdtree.query(data[:100], k=30)
+distances, indices, num_neighbors = kdtree.query(data[:100], k=30)
 
 # query all points in a radius around the first 100 points
 indices = kdtree.query_radius(data[:100], r=0.5, return_sorted=True)

--- a/src/ckdtree/rectangle.h
+++ b/src/ckdtree/rectangle.h
@@ -11,6 +11,7 @@
 #include <cmath>
 #include <cstring>
 #include <vector>
+#include <cstdint>
 #include "ckdtree_decl.h"
 
 /* Interval arithmetic

--- a/tests/test_kdtree.py
+++ b/tests/test_kdtree.py
@@ -168,12 +168,14 @@ def test_kdtree_query_radius_parallel(data, kdtree, scipy_kdtree):
 
 
 def test_argument_conversion(data, kdtree):
+    import warnings
     # conversion of scalar arguments
     _, ii_test, _ = kdtree.query(data[0], k=10)
-
-    # conversion of lists
-    _, ii, _ = kdtree.query([data[0]], k=10)
-    assert np.all(ii == ii_test)
+    with warnings.catch_warnings():
+        # conversion of lists (this is deprecated but should still work as long as the typed list is not the default yet)
+        warnings.simplefilter("ignore", nb.errors.NumbaPendingDeprecationWarning)
+        _, ii, _ = kdtree.query([data[0]], k=10)
+        assert np.all(ii == ii_test)
 
     # conversion of numba lists
     _, ii, _ = kdtree.query(nb.typed.List([data[0]]), k=10)
@@ -181,7 +183,10 @@ def test_argument_conversion(data, kdtree):
 
     # conversion of manually specified arrays
     _, ii_test, _ = kdtree.query(np.array([0, 0, 0]), k=10)
-    _, ii2, _ = kdtree.query([0, 0, 0], k=10)
+    with warnings.catch_warnings():
+        # conversion of lists (this is deprecated but should still work as long as the typed list is not the default yet)
+        warnings.simplefilter("ignore", nb.errors.NumbaPendingDeprecationWarning)
+        _, ii2, _ = kdtree.query([0, 0, 0], k=10)
     assert np.all(ii2 == ii_test)
 
 


### PR DESCRIPTION
This suppresses some warnings related to compilation with parallel=True (NumbaPerformanceWarning)  in the query functions as well as reflected lists in the tests (NumbaPendingDeprecationWarning) as long as typed.List is not the default for python-list conversion.