### PR TITLE
Search for correct package in __init__

### DIFF
--- a/numba_kdtree/__init__.py
+++ b/numba_kdtree/__init__.py
@@ -1,7 +1,7 @@
 try:
     from importlib.metadata import version
 
-    __version__ = version("pyvista_imgui")
+    __version__ = version("numba_kdtree")
 except Exception:  # pragma: no cover # pylint: disable=broad-exception-caught
     try:
         from ._version import __version__


### PR DESCRIPTION
The changes in #18 ask `importlib.metadata` for the version of a package named `pyvista_imgui` instead of `numba_kdtree`.