### PR TITLE
Remove deprecated usage of generated_jit and additional cleanup

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -67,8 +67,6 @@ class build_ext(build_ext_orig):
 with open("README.md", "r", encoding="utf-8") as fh:
     long_description = fh.read()
 
-#version = import_module_from_path('numba_kdtree/_version.py').__version__
-
 if platform.system() == "Windows":
     extra_compile_args = ['/O2', '/DKDTREE_COMPILING=1']
 else:

--- a/tests/test_kdtree.py
+++ b/tests/test_kdtree.py
@@ -1,6 +1,5 @@
 import pytest
-from numba_kdtree import KDTree
-from numba_kdtree.kd_tree import KDTreeProxy
+from numba_kdtree import KDTree, KDTreeType
 import numpy as np
 from scipy.spatial import cKDTree
 import numba as nb
@@ -14,7 +13,7 @@ def data():
 
 
 @pytest.fixture(scope='module')
-def kdtree(data) -> KDTreeProxy:
+def kdtree(data) -> KDTreeType:
     kd_tree = KDTree(data, leafsize=10, balanced=False, compact=False)
     return kd_tree
 
@@ -57,9 +56,10 @@ def test_kdtree_build(data):
           runtime_kdtree_f, "\nkdtree(double):", runtime_kdtree_d)
 
 
-def test_kdtree_query(data, kdtree: KDTreeProxy, scipy_kdtree):
+def test_kdtree_query(data, kdtree: KDTreeType, scipy_kdtree):
     k = 10
     dd, ii, nn = kdtree.query(data[:1], k=k)  # pre-compile
+
     # query the nearest neighbors of each input point in a single thread
     dd, ii, nn = kdtree.query(data, k=k)
     dd_scipy, ii_scipy = scipy_kdtree.query(data, k=k, workers=1)
@@ -80,7 +80,7 @@ def test_kdtree_query(data, kdtree: KDTreeProxy, scipy_kdtree):
 def test_kdtree_query_parallel(data, kdtree, scipy_kdtree):
     k = 10
     dd, ii, nn = kdtree.query_parallel(data[:1], k=k)  # pre-compile
-
+    
     # query using all available cpu cores
     dd, ii, nn = kdtree.query_parallel(data, k=k)  # pre-compile
     dd_scipy, ii_scipy = scipy_kdtree.query(data, k=k, workers=-1)

--- a/tests/test_kdtree.py
+++ b/tests/test_kdtree.py
@@ -1,5 +1,6 @@
 import pytest
 from numba_kdtree import KDTree
+from numba_kdtree.kd_tree import KDTreeProxy
 import numpy as np
 from scipy.spatial import cKDTree
 import numba as nb
@@ -13,7 +14,7 @@ def data():
 
 
 @pytest.fixture(scope='module')
-def kdtree(data):
+def kdtree(data) -> KDTreeProxy:
     kd_tree = KDTree(data, leafsize=10, balanced=False, compact=False)
     return kd_tree
 
@@ -56,10 +57,9 @@ def test_kdtree_build(data):
           runtime_kdtree_f, "\nkdtree(double):", runtime_kdtree_d)
 
 
-def test_kdtree_query(data, kdtree, scipy_kdtree):
+def test_kdtree_query(data, kdtree: KDTreeProxy, scipy_kdtree):
     k = 10
     dd, ii, nn = kdtree.query(data[:1], k=k)  # pre-compile
-
     # query the nearest neighbors of each input point in a single thread
     dd, ii, nn = kdtree.query(data, k=k)
     dd_scipy, ii_scipy = scipy_kdtree.query(data, k=k, workers=1)

--- a/tests/test_kdtree.py
+++ b/tests/test_kdtree.py
@@ -79,7 +79,7 @@ def test_kdtree_query(data, kdtree: KDTreeType, scipy_kdtree):
 
 def test_kdtree_query_parallel(data, kdtree, scipy_kdtree):
     k = 10
-    dd, ii, nn = kdtree.query_parallel(data[:1], k=k)  # pre-compile
+    #dd, ii, nn = kdtree.query_parallel(data[:1], k=k)  # pre-compile
     
     # query using all available cpu cores
     dd, ii, nn = kdtree.query_parallel(data, k=k)  # pre-compile
@@ -147,9 +147,8 @@ def test_kdtree_query_radius(data, kdtree, scipy_kdtree):
 
 
 def test_kdtree_query_radius_parallel(data, kdtree, scipy_kdtree):
-    ii = kdtree.query_radius_parallel(data[:1], r=0.01, return_sorted=True, workers=-1)
 
-    ii = kdtree.query_radius_parallel(data[:100], r=0.01, return_sorted=True, workers=-1)
+    ii = kdtree.query_radius_parallel(data[:100], r=0.01, return_sorted=True)
     ii_scipy = scipy_kdtree.query_ball_point(data[:100], r=0.01, return_sorted=True, workers=-1)
 
     for i in range(len(ii)):
@@ -158,7 +157,7 @@ def test_kdtree_query_radius_parallel(data, kdtree, scipy_kdtree):
 
     num_executions = 5
     r_benchmark = 0.1
-    runtime_kdtree_query = timeit(lambda: kdtree.query_radius_parallel(data[:500], r=r_benchmark, return_sorted=True, workers=-1),
+    runtime_kdtree_query = timeit(lambda: kdtree.query_radius_parallel(data[:500], r=r_benchmark, return_sorted=True),
                               number=num_executions) / num_executions
     runtime_scipy_query = timeit(lambda: scipy_kdtree.query_ball_point(data[:500], r=r_benchmark,
                                                                        return_sorted=True, workers=-1),
@@ -220,11 +219,8 @@ def test_kdtree_query_radius_conversion(data, kdtree):
 
 
 def test_kdtree_query_radius_array_parallel(data, kdtree, scipy_kdtree):
-    # pre compile
-    ii = kdtree.query_radius_parallel(data[:1], r=0.01, return_sorted=True, workers=-1)
-
     radii = np.linspace(0.01, 0.05, 100)
-    ii = kdtree.query_radius_parallel(data[:100], r=radii, return_sorted=True, workers=-1)
+    ii = kdtree.query_radius_parallel(data[:100], r=radii, return_sorted=True)
     ii_scipy = scipy_kdtree.query_ball_point(data[:100], r=radii, return_sorted=True, workers=-1)
 
     for i in range(len(ii)):
@@ -233,7 +229,7 @@ def test_kdtree_query_radius_array_parallel(data, kdtree, scipy_kdtree):
 
     num_executions = 5
     r_benchmark = np.linspace(0.01, 0.05, 500)
-    runtime_kdtree_query = timeit(lambda: kdtree.query_radius_parallel(data[:500], r=r_benchmark, return_sorted=True, workers=-1),
+    runtime_kdtree_query = timeit(lambda: kdtree.query_radius_parallel(data[:500], r=r_benchmark, return_sorted=True),
                               number=num_executions) / num_executions
     runtime_scipy_query = timeit(lambda: scipy_kdtree.query_ball_point(data[:500], r=r_benchmark,
                                                                        return_sorted=True, workers=-1),
@@ -301,13 +297,13 @@ def test_use_in_numba_function_parallel(data, kdtree):
 
     # pre compile
     ii = query_numba_parallel(data, kdtree, 10)
-    dd, ii, nn = kdtree.query_parallel(data[:1], k=10, workers=-1)  # pre-compile
+    dd, ii, nn = kdtree.query_parallel(data[:1], k=10)  # pre-compile
 
     num_executions = 5
     k_benchmark = 30
 
     # run times should be very similar here
-    runtime_kdtree_query = timeit(lambda: kdtree.query_parallel(data, k=k_benchmark, workers=-1),
+    runtime_kdtree_query = timeit(lambda: kdtree.query_parallel(data, k=k_benchmark),
                               number=num_executions) / num_executions
     runtime_numba_kdtree_query = timeit(lambda: query_numba_parallel(data, kdtree, k_benchmark),
                               number=num_executions) / num_executions
@@ -341,10 +337,10 @@ def test_pickle(data, kdtree):
 
     k = 10
     # query the old tree
-    dd, ii, nn = kdtree.query_parallel(data[:100], k=k, workers=-1)
+    dd, ii, nn = kdtree.query_parallel(data[:100], k=k)
 
     # query the new tree
-    dd_r, ii_r, nn_r = restored_kdtree.query_parallel(data[:100], k=k, workers=-1)
+    dd_r, ii_r, nn_r = restored_kdtree.query_parallel(data[:100], k=k)
 
     assert np.allclose(dd, dd_r)
     assert np.all(ii == ii_r)


### PR DESCRIPTION
This PR replaces the deprecated generated_jit function with the overload mechanism. Additionally, it adds docstrings for most functions and removes the automatic thread count modification in the parallel query functions in favor of an explicit modification in the user's code.