### PR TITLE
Use the numba runtime (NRT) to manage external memory

### DIFF
--- a/numba_kdtree/ckdtree.py
+++ b/numba_kdtree/ckdtree.py
@@ -24,7 +24,8 @@ ckdtree = CKDTreeFunctions
 float_ptr = types.CPointer(types.float32)
 double_ptr = types.CPointer(types.double)
 ssize_t_ptr = types.CPointer(types.ssize_t)
-ckdtree_handle = types.size_t
+ckdtree_handle = types.voidptr
+meminfo_handle = types.MemInfoPointer(types.voidptr)
 
 try:
     binding.load_library_permanently(str(library_path / library_name))
@@ -49,11 +50,12 @@ ckdtree.copy_tree = {}
 
 
 for numba_type, (c_type, ptr_type) in _supported_types.items():
-    ckdtree.init[numba_type] = types.ExternalFunction(f"ckdtree_init_{c_type}", ckdtree_handle(
-        types.voidptr,
-        types.ssize_t,
-        ptr_type,
-        ssize_t_ptr,
+    ckdtree.init[numba_type] = types.ExternalFunction(f"ckdtree_init_{c_type}", meminfo_handle(
+        types.voidptr, #nrt
+        types.voidptr, # preexisting tree buffer
+        types.ssize_t, # tree buffer size
+        ptr_type, # data pointer
+        ssize_t_ptr, # size of data
         types.ssize_t,
         types.ssize_t,
         types.ssize_t,
@@ -61,9 +63,9 @@ for numba_type, (c_type, ptr_type) in _supported_types.items():
         ptr_type
     ))
 
-    ckdtree.free[numba_type] = types.ExternalFunction(f"ckdtree_free_{c_type}", types.void(
-        ckdtree_handle
-    ))
+    # ckdtree.free[numba_type] = types.ExternalFunction(f"ckdtree_free_{c_type}", types.void(
+    #     ckdtree_handle
+    # ))
 
     ckdtree.build[numba_type] = types.ExternalFunction(f"ckdtree_build_{c_type}", types.int32(
         ckdtree_handle,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,3 @@
 [build-system]
-requires = ["setuptools", "wheel", "setuptools_scm>=6.2"]
+requires = ["setuptools", "wheel", "setuptools_scm>=6.2", "numba>=0.52"]
 build-backend = "setuptools.build_meta"

--- a/setup.py
+++ b/setup.py
@@ -4,6 +4,7 @@ from distutils.sysconfig import get_python_inc
 from os.path import join, dirname
 from distutils.sysconfig import customize_compiler
 import platform
+import numba.extending as nbe
 
 # standalone import of a module (https://stackoverflow.com/a/58423785)
 def import_module_from_path(path):
@@ -25,13 +26,14 @@ def import_module_from_path(path):
         module = sys.modules
     return module
 
-inc_dirs = [get_python_inc()]
+inc_dirs = [get_python_inc(), nbe.include_path()]
 inc_dirs.append(join(dirname(dirname(__file__)), 'src', 'ckdtree'))
 
 ckdtree_src = ['init.cpp',
                'build.cpp',
                'query.cpp',
-               'query_radius.cpp']
+               'query_radius.cpp'
+               ]
 
 ckdtree_src = [join('src', 'ckdtree', x) for x in ckdtree_src]
 
@@ -70,7 +72,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
 if platform.system() == "Windows":
     extra_compile_args = ['/O2', '/DKDTREE_COMPILING=1']
 else:
-    extra_compile_args = ['-fPIC', '-shared', '-O3', '-DKDTREE_COMPILING=1']
+    extra_compile_args = ['-fPIC', '-shared', '-g', '-DKDTREE_COMPILING=1']
     if platform.system() == "Darwin":
         extra_compile_args.append('-std=c++11')
 

--- a/src/ckdtree/build.cpp
+++ b/src/ckdtree/build.cpp
@@ -159,8 +159,8 @@ build(ckdtree<T>* self, ckdtree_intp_t start_idx, ckdtree_intp_t end_idx,
         }
 
         if (CKDTREE_LIKELY(_compact)) {
-            _less = build(self, start_idx, p, maxes, mins, _median, _compact);
-            _greater = build(self, p, end_idx, maxes, mins, _median, _compact);
+            _less = build<T>(self, start_idx, p, maxes, mins, _median, _compact);
+            _greater = build<T>(self, p, end_idx, maxes, mins, _median, _compact);
         }
         else
         {
@@ -169,11 +169,11 @@ build(ckdtree<T>* self, ckdtree_intp_t start_idx, ckdtree_intp_t end_idx,
 
             for (i=0; i<m; ++i) mids[i] = maxes[i];
             mids[d] = split;
-            _less = build(self, start_idx, p, mins, mids, _median, _compact);
+            _less = build<T>(self, start_idx, p, mins, mids, _median, _compact);
 
             for (i=0; i<m; ++i) mids[i] = mins[i];
             mids[d] = split;
-            _greater = build(self, p, end_idx, mids, maxes,  _median, _compact);
+            _greater = build<T>(self, p, end_idx, mids, maxes,  _median, _compact);
         }
 
         /* recompute n because std::vector can
@@ -185,7 +185,6 @@ build(ckdtree<T>* self, ckdtree_intp_t start_idx, ckdtree_intp_t end_idx,
         n->_greater = _greater;
         n->split_dim = d;
         n->split = split;
-
         return node_index;
     }
 }
@@ -197,9 +196,12 @@ int ckdtree_build_float(ckdtree_float* self, ckdtree_intp_t start_idx, ckdtree_i
     if (!self) {
         return 1;
     }
+    std::cout << "building float" << std::endl;
+
     //auto self = (ckdtree<float>*) self_; // cast the void pointer
     build<float>(self, start_idx, end_idx, mins, maxes, _balanced, _compact);
     self->size = self->tree_buffer.size();
+    std::cout << "built " << self->size << std::endl;
     return 0;
 }
 
@@ -208,9 +210,13 @@ int ckdtree_build_double(ckdtree_double* self, ckdtree_intp_t start_idx, ckdtree
     if (!self) {
         return 1;
     }
+    std::cout << "building double" << std::endl;
+
     //auto self = (ckdtree<double>*) self_; // cast the void pointer
     build<double>(self, start_idx, end_idx, mins, maxes, _balanced, _compact);
     self->size = self->tree_buffer.size();
+    std::cout << "built " << self->size << std::endl;
+
 
     return 0;
 }

--- a/src/ckdtree/ckdtree.h
+++ b/src/ckdtree/ckdtree.h
@@ -31,24 +31,20 @@ extern "C"
 #endif
 
 #include "ckdtree_decl.h"
-
+typedef struct MemInfo NRT_MemInfo;
 typedef struct ckdtree<float> ckdtree_float;
 typedef struct ckdtree<double> ckdtree_double;
 
 /* Init and Free methods in C */
-KDTREE_PUBLIC ckdtree_float* ckdtree_init_float(char* tree_buffer, ckdtree_intp_t buffer_size, 
+KDTREE_PUBLIC NRT_MemInfo* ckdtree_init_float(void* nrt, char* tree_buffer, ckdtree_intp_t buffer_size, 
                                   float* data, ckdtree_intp_t* indices, 
                                   ckdtree_intp_t n, ckdtree_intp_t m,
                                   ckdtree_intp_t leafsize, float *mins, float *maxes);
 
-KDTREE_PUBLIC ckdtree_double* ckdtree_init_double(char* tree_buffer, ckdtree_intp_t buffer_size, 
+KDTREE_PUBLIC NRT_MemInfo* ckdtree_init_double(void* nrt, char* tree_buffer, ckdtree_intp_t buffer_size, 
                                     double* data, ckdtree_intp_t* indices, 
                                     ckdtree_intp_t n, ckdtree_intp_t m,
                                     ckdtree_intp_t leafsize, double *mins, double *maxes);
-
-KDTREE_PUBLIC void ckdtree_free_float(ckdtree_float* self);
-
-KDTREE_PUBLIC void ckdtree_free_double(ckdtree_double* self);
 
 /* Build methods in C */
 KDTREE_PUBLIC int

--- a/src/ckdtree/init.cpp
+++ b/src/ckdtree/init.cpp
@@ -5,13 +5,29 @@
 #include "ckdtree_decl.h"
 #include "ckdtree.h"
 #include <cstring>
+#include "numba/core/runtime/nrt_external.h"
+
+namespace detail {
+    template<typename T>
+    void free_ckdtree(void* self) {
+        auto self_t = reinterpret_cast<ckdtree<T>*>(self);
+        delete self_t;
+    }
+}
 
 template<typename T>
-ckdtree<T>* init_ckdtree(char* tree_buffer, ckdtree_intp_t buffer_size, 
-                         T* data, ckdtree_intp_t* indices, 
-                         ckdtree_intp_t n, ckdtree_intp_t m,
-                         ckdtree_intp_t leafsize, T *mins, T *maxes) {
-    ckdtree<T>* self = new ckdtree<T>;
+NRT_MemInfo* init_ckdtree(NRT_api_functions* nrt,
+                          char* tree_buffer, 
+                          ckdtree_intp_t buffer_size, 
+                          T* data, 
+                          ckdtree_intp_t* indices, 
+                          ckdtree_intp_t n, 
+                          ckdtree_intp_t m,
+                          ckdtree_intp_t leafsize, 
+                          T *mins, 
+                          T *maxes) {
+    ckdtree<T>* self = new ckdtree<T>(); 
+    NRT_MemInfo *mi = nrt->manage_memory(self, detail::free_ckdtree<T>);
     if(tree_buffer != nullptr) {
         // initialize existing tree
         auto buffer_ptr = reinterpret_cast<ckdtreenode<T>*>(tree_buffer);
@@ -25,89 +41,56 @@ ckdtree<T>* init_ckdtree(char* tree_buffer, ckdtree_intp_t buffer_size,
     self->raw_maxes = maxes;
     self->raw_mins = mins;
     self->raw_indices = indices;
-    return self;
+
+    return mi;
 }
 
 // c interface methods
-ckdtree_float* ckdtree_init_float(char* tree_buffer, ckdtree_intp_t buffer_size, 
+NRT_MemInfo* ckdtree_init_float(void* nrt, char* tree_buffer, ckdtree_intp_t buffer_size, 
                                   float* data, ckdtree_intp_t* indices, 
                                   ckdtree_intp_t n, ckdtree_intp_t m,
                                   ckdtree_intp_t leafsize, float *mins, float *maxes) {
-    return init_ckdtree<float>(tree_buffer, buffer_size, data, indices, n, m, leafsize, mins, maxes);
+    return init_ckdtree<float>(reinterpret_cast<NRT_api_functions*>(nrt), tree_buffer, buffer_size, data, indices, n, m, leafsize, mins, maxes);
 }
 
-ckdtree_double* ckdtree_init_double(char* tree_buffer, ckdtree_intp_t buffer_size, 
+NRT_MemInfo* ckdtree_init_double(void* nrt, char* tree_buffer, ckdtree_intp_t buffer_size, 
                                     double* data, ckdtree_intp_t* indices, 
                                     ckdtree_intp_t n, ckdtree_intp_t m,
                                     ckdtree_intp_t leafsize, double *mins, double *maxes) {
-    return init_ckdtree<double>(tree_buffer, buffer_size, data, indices, n, m, leafsize, mins, maxes);
+    return init_ckdtree<double>(reinterpret_cast<NRT_api_functions*>(nrt), tree_buffer, buffer_size, data, indices, n, m, leafsize, mins, maxes);
 }
-
-void ckdtree_free_float(ckdtree_float* self) {
-    //printf("free c data float\n");
-    //auto self_t = (ckdtree<float>*) self;
-    if(self != nullptr) {
-        delete self;
-    }
-    self = nullptr;
-}
-
-void ckdtree_free_double(ckdtree_double* self) {
-    //printf("free c data double\n");
-    //auto self_t = (ckdtree<double>*) self;
-    //delete self_t->tree_buffer;
-    if(self != nullptr) {
-        delete self;
-    }
-    self = nullptr;
-}
-
-#define RETURN_UNINITIALIZED(self) \
-    if(!self){ \
-        return -1; \
-    }
 
 ssize_t ckdtree_size_float(ckdtree_float* self) {
-    RETURN_UNINITIALIZED(self)
-    //auto self_t = (ckdtree<float>*) self;
     return self->size;
 }
 
 ssize_t ckdtree_size_double(ckdtree_double* self) {
-    RETURN_UNINITIALIZED(self)
-    //auto self_t = (ckdtree<double>*) self;
     return self->size;
 }
 
 ckdtree_intp_t leafsize_float(ckdtree_float* self) {
-    RETURN_UNINITIALIZED(self)
     return self->leafsize;
 }
 
 ckdtree_intp_t leafsize_double(ckdtree_double* self) {
-    RETURN_UNINITIALIZED(self)
     return self->leafsize;
 }
 
 ckdtree_intp_t nodesize_float(ckdtree_float* self) {
-    RETURN_UNINITIALIZED(self)
     return sizeof(ckdtreenode<float>);
 }
 
 ckdtree_intp_t nodesize_double(ckdtree_double* self) {
-    RETURN_UNINITIALIZED(self)
     return sizeof(ckdtreenode<double>);
 }
 
 ckdtree_intp_t copy_tree_float(ckdtree_float* self, char* buffer) {
-    RETURN_UNINITIALIZED(self)
     size_t size = self->tree_buffer.size() * sizeof(ckdtreenode<float>);
     memcpy(buffer, self->tree_buffer.data(), size);
     return size;
 }
 
 ckdtree_intp_t copy_tree_double(ckdtree_double* self, char* buffer) {
-    RETURN_UNINITIALIZED(self)
     size_t size = self->tree_buffer.size() * sizeof(ckdtreenode<double>);
     memcpy(buffer, self->tree_buffer.data(), size);
     return size;


### PR DESCRIPTION
This makes the ckdtree implementation utilize the numba runtime (NRT) to manage the allocated memory for the internal c struct and modifies the implementation accordingly. In particular, this should make the deallocation upon destruction much safer as it is now the NRT's responsibility to free the c struct.  